### PR TITLE
Updates to upstream library #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,6 @@
 Sikorka Android Application
 ---------
 
-### Geth Android Library
-
-The go-ethereum android aar is build from [https://github.com/kelsos/go-ethereum/tree/sikorka-abi-unmarshal-fix](https://github.com/kelsos/go-ethereum/tree/sikorka-abi-unmarshal-fix)
-due to issue 14832 of go-ethereum that causes `'abi: cannot unmarshal x in to []interface {}'` when
-trying to interact with smart contracts.
-
-The library is deployed on bintray with a different `groupId` and `artifactId` from the artifact deployed
-on maven central in order to avoid confusion.
-
-As soon as the issue is fixed upstream the dependency will be updated to the official artifact. 
-
 ### Google Maps 
 For google maps integration you should provide a `api-keys.properties` file in the project `root directory`
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,10 +86,7 @@ dependencies {
 
   implementation 'com.android.support.constraint:constraint-layout:1.1.0-beta4'
 
-  // Custom build of master with an addition to an unmarshal issue
-  // https://github.com/ethereum/go-ethereum/issues/14832#issuecomment-322965627
-  // build of 049797d40 master (plus mobile single unmarshal fix)
-  implementation 'geth-android:geth:1.7.3-unstable'
+  implementation 'org.ethereum:geth:1.8.2'
 
   implementation 'com.squareup.moshi:moshi-kotlin:1.5.0'
   implementation 'com.squareup.okio:okio:1.13.0'


### PR DESCRIPTION
1.8.2 go ethereum fixes the issues with contract binding so there is no need for a custom artifact.